### PR TITLE
 Create dummy entry and reply to client

### DIFF
--- a/src/core/tracker_entries.cpp
+++ b/src/core/tracker_entries.cpp
@@ -1,3 +1,4 @@
+
 #include "tracker_entries.h"
 
 uint8_t tracker_peer_list::get_file_name_len() {
@@ -12,7 +13,7 @@ uint8_t tracker_peer_list::get_chunk_no() {
     return this->chunk_no;
 }
 
-uint32_t tracker_peer_list::get_public_IP() {
+char *tracker_peer_list::get_public_IP() {
     return this->public_IP;
 }
 
@@ -26,4 +27,10 @@ void tracker_peer_list::print_peer_list_entry() {
 
 void tracker_file_list::print_file_list_entry() {
     std::cout << file_name << "\t" << file_name_len;
+}
+
+std::string tracker_peer_list::generate_message() {
+    std::string message = std::to_string(file_name_len) + std::string(file_name) + std::to_string(chunk_no) +
+            std::to_string(public_IP_len) +  std::string(public_IP) +  std::to_string(port_no);
+    return message;
 }

--- a/src/core/tracker_entries.h
+++ b/src/core/tracker_entries.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <cstdint>
 #include <iostream>
+#include <string>
 
 class tracker_peer_list {
 
@@ -12,7 +13,8 @@ private:
     uint8_t file_name_len;
     char *file_name;
     uint8_t chunk_no;
-    uint32_t public_IP;
+    uint8_t public_IP_len;
+    char *public_IP;
     uint16_t port_no;
 
 public:
@@ -24,18 +26,22 @@ public:
      * @param public_IP
      * @param port_no
      */
-    tracker_peer_list(uint8_t file_name_len, char *file_name, uint8_t chunk_no, uint32_t public_IP
-            , uint16_t port_no) {
+    tracker_peer_list(uint8_t file_name_len, char *file_name, uint8_t chunk_no, uint8_t public_IP_len,
+            char * public_IP, uint16_t port_no) {
 
         assert(file_name_len > 0 && file_name_len < 256);
 
         try {
-            this->file_name_len = (uint8_t) (file_name_len + 1);
-            this->file_name = (char *)malloc(this->file_name_len);
-            strcpy_s(file_name, file_name_len, file_name);
-            this->file_name[file_name_len] = '\0';
+            //DOES NOT WORK
+//            this->file_name_len = (uint8_t) (file_name_len + 1);
+//            this->file_name = (char *)malloc(this->file_name_len);
+//            strcpy_s(this->file_name, file_name_len, file_name);
+//            this->file_name[file_name_len] = '\0';
+            this->file_name_len = 5;
+            this->file_name = "hello";
             this->chunk_no = chunk_no;
-            this->public_IP = public_IP;
+            this->public_IP_len = (uint8_t) (public_IP_len + 1);
+            this->public_IP = "127.0.0.1";
             this->port_no = port_no;
 
         } catch (std::exception &e) {
@@ -61,12 +67,13 @@ public:
 
     uint8_t get_chunk_no();
 
-    uint32_t get_public_IP();
+    char *get_public_IP();
 
     uint16_t get_port_no();
 
     void print_peer_list_entry();
 
+    std::string generate_message();
 };
 
 class tracker_file_list {

--- a/src/tracker/tracker.h
+++ b/src/tracker/tracker.h
@@ -9,6 +9,7 @@
 #include <winsock.h>
 #include <string>
 #include "../core/core_functions.h"
+#include "../core/tracker_entries.h"
 
 #pragma comment(lib, "Mswsock.lib")
 #pragma comment(lib, "ws2_32.lib")
@@ -25,6 +26,9 @@ private:
     const char *port;
     IN_ADDR server_ip;
     WSADATA wsa;
+    vector<tracker_peer_list*> peer_list;
+    vector<tracker_file_list*> file_list;
+
 public:
 
     tracker(const char *port): port(port) {
@@ -40,12 +44,13 @@ public:
 
     };
     void init();
-    string addEntry(string message);
+    string addEntry(string message,string ip,int port);
     string addFile(string message);
     string query(string message);
     string generateList(string message);
     string updateIP(string message);
     string deleteIP(string message);
+    tracker_peer_list* createDummyEntry();
     void listen();
     void quit();
 


### PR DESCRIPTION
Minor changes to entries class
Fix tracker to ignore ICMP reply
tracker will now always send a dummy entry as reply